### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 # on:
 #   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/kktos/jsasm6502/security/code-scanning/1](https://github.com/kktos/jsasm6502/security/code-scanning/1)

To fix the issue, add a `permissions` block that reduces the permissions for the job/workflow to the minimum required. In this workflow, since there are no steps needing write access to repository contents, issues, or pull requests, the minimal starting point is to set `permissions: contents: read`. This can be done either at the root of the workflow file, which will apply to all jobs, or directly in the job (`ci`) block if there are/will be multiple jobs requiring different permissions. Here, adding to the root (just below `name: CI`) is sufficient and preferred, making all jobs secure by default.

Changes needed:
- Insert the following block immediately under the workflow name:
  ```yaml
  permissions:
    contents: read
  ```
No extra imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
